### PR TITLE
fixed manual and imported records to be removed from the app

### DIFF
--- a/app/(tabs)/activity.tsx
+++ b/app/(tabs)/activity.tsx
@@ -376,11 +376,27 @@ export default function Activity() {
                 return;
             }
     
-            const { error: deleteError } = await supabase
-                .from('activity_logs')
-                .delete()
-                .eq('id', activity.id)
-                .eq('user_id', user.id);
+            let deleteError;
+
+            if (activity.source === 'manual') {
+                const result = await supabase
+                    .from('activity_logs')
+                    .delete()
+                    .eq('id', activity.id)
+                    .eq('user_id', user.id)
+                    .eq('source', 'manual');
+
+                deleteError = result.error;
+            } else {
+                const result = await supabase
+                    .from('activity_logs')
+                    .update({ is_hidden: true })
+                    .eq('id', activity.id)
+                    .eq('user_id', user.id)
+                    .in('source', ['healthkit', 'health_connect']);
+
+                deleteError = result.error;
+            }
     
             if (deleteError) {
                 setError(`Activity could not be deleted: ${deleteError.message}`);


### PR DESCRIPTION
manual activities are permanently deleted
imported activities are only hidden
hidden imported activities will not reappear in Activity history or the Dashboard
their stored external_workout_id remains available for deduplication