### PR TITLE
give the screen up to about 5 seconds to reload the newly created row…

### DIFF
--- a/app/(tabs)/insights.tsx
+++ b/app/(tabs)/insights.tsx
@@ -191,8 +191,16 @@ export default function Insights() {
         const result = await generateInsights();
     
         if (result.success) {
-            await loadInsights(false);
-    
+
+            // retry briefly after generation so the UI recovers cleanly when connectivity has only just been restored.
+            for (let attempt = 0; attempt < 5; attempt++) {
+                await loadInsights(attempt > 0);
+        
+                if (attempt < 4) {
+                    await new Promise(resolve => setTimeout(resolve, 1000));
+                }
+            }
+        
             setMessage(null);
         } else {
             setMessage(result.message ?? 'Something went wrong. Please try again.');

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -361,7 +361,7 @@ const getHealthConnectWorkouts = async (): Promise<WorkoutData[]> => {
             56: 'running',
             8: 'cycling',
             82: 'swimming',
-            64: 'strength',
+            70: 'strength',
             61: 'yoga',
             73: 'tennis',
             30: 'golf',


### PR DESCRIPTION
…s rather than relying on one request immediately after network restoration.